### PR TITLE
Fix `setClient` issue for new guzzle version

### DIFF
--- a/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
+++ b/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php
@@ -72,7 +72,8 @@ class GoutteFactory implements DriverFactory
             $config['server_parameters'],
         );
         $guzzleClient = null;
-
+        
+        
         if ($this->isGoutte4()) {
             $clientArguments = array();
 
@@ -83,8 +84,10 @@ class GoutteFactory implements DriverFactory
             }
         } elseif ($this->isGoutte1()) {
             $guzzleClient = $this->buildGuzzle3Client($config['guzzle_parameters']);
-        } elseif ($this->isGuzzle6()) {
-            $guzzleClient = $this->buildGuzzle6Client($config['guzzle_parameters']);
+        } else if ($this->isGuzzle6()) {
+            $clientDefinition = new Definition('Behat\Mink\Driver\Goutte\Client');
+
+            return new Definition('Behat\Mink\Driver\GoutteDriver', array($clientDefinition));
         } else {
             $guzzleClient = $this->buildGuzzle4Client($config['guzzle_parameters']);
         }


### PR DESCRIPTION
Fixes an issue where we get this error message when using the MinkExtension:

```
In GoutteFactory.php line 117:

  Method Goutte\Client::setClient() does not exist
```

Fix is located here https://github.com/Behat/MinkExtension/pull/381 but is yet to be merged and is blocking me from moving forward with my ticket